### PR TITLE
Simplify check command logic

### DIFF
--- a/src/commands/check.js
+++ b/src/commands/check.js
@@ -1,8 +1,7 @@
 import glob from 'glob';
-import path from 'path';
 import { CLIEngine } from 'eslint';
 import LintRunner from '../LintRunner';
-import { clearLine } from '../cliUtils';
+import { flatten } from '../util';
 
 const ROOT_DIR = process.cwd();
 const eslint = new CLIEngine({ cwd: ROOT_DIR });
@@ -15,49 +14,21 @@ export const check = (options) => {
   } = options;
 
   const lintRunner = new LintRunner(workers);
+  
+  const filePaths = flatten(paths.map(globPath => glob.sync(globPath)));
 
-  let filePaths = [];
-  process.stdout.write('Reading files to be linted...[this may take a little bit]');
-  for (let i = 0; i < paths.length; i++) {
-    const files = glob.sync(paths[i], {});
-    files.forEach((file) => {
-      filePaths.push(file);
-    });
-  }
-
-  let filesToProcess = 0;
-  let lintResults = [];
-
-  filePaths.map((file) => {
-    if (eslint.isPathIgnored(path.join(ROOT_DIR, file)) || file.indexOf('eslint') !== -1) {
-      return;
-    }
-    filesToProcess++;
-    lintRunner.run({ cwd: ROOT_DIR }, [file])
-      .then((results) => {
-        const result = results[0];
-        lintResults.push(result);
-        filesToProcess--;
-      });
-  });
-
-  const interval = setInterval(() => {
-    clearLine();
-    process.stdout.write(`Linting files...${filesToProcess} left to lint`);
-
-    if (filesToProcess === 0) {
-      clearInterval(interval);
-      lintResults = lintResults.filter((result) => {
+  lintRunner.run({ cwd: ROOT_DIR }, filePaths)
+    .then((results) => {
+      results = results.filter((result) => {
         return result.warningCount > 0 || result.errorCount > 0;
       });
 
       if (json) {
-        console.log(JSON.stringify(lintResults));
+        console.log(JSON.stringify(results));
       } else {
         const formatter = eslint.getFormatter();
-        console.log(formatter(lintResults));
+        console.log(formatter(results));
       }
-      process.exit(lintResults.length > 0 ? 1 : 0);
-    }
-  }, 1000);
+      process.exit(results.length > 0 ? 1 : 0);
+    });
 };


### PR DESCRIPTION
You can pass all files to the lint runner instead of one by one. Should greatly improve performance of the check command, but we lose progress indication, which we can add back in elegantly in the future.