### PR TITLE
Fix server check from inside subfolder

### DIFF
--- a/src/Server.js
+++ b/src/Server.js
@@ -57,7 +57,10 @@ export default class Server {
       process.send({message: 'Reading files to be linted...[this may take a little bit]'});
       let filePaths = [];
       for (let i = 0; i < paths.length; i++) {
-        const files = glob.sync(paths[i], {});
+        const files = glob.sync(paths[i], {
+          cwd: root,
+          absolute: true,
+        });
         files.forEach((file) => {
           filePaths.push(file);
         });
@@ -71,7 +74,10 @@ export default class Server {
       if (filepath.indexOf('.eslintrc') !== -1) {
         this.cache = {};
         for (let i = 0; i < paths.length; i++) {
-          const files = glob.sync(paths[i], {});
+          const files = glob.sync(paths[i], {
+            cwd: root,
+            absolute: true,
+          });
           files.forEach((file) => {
             filePaths.push(file);
           });
@@ -105,7 +111,7 @@ export default class Server {
   }
 
   lintFile(file) {
-    if (eslint.isPathIgnored(path.join(ROOT_DIR, file)) || file.indexOf('eslint') !== -1) {
+    if (eslint.isPathIgnored(file) || file.indexOf('eslint') !== -1) {
       return;
     }
     this.filesToProcess++;

--- a/tests/subfolders/__tests__/subfolders.test.js
+++ b/tests/subfolders/__tests__/subfolders.test.js
@@ -21,16 +21,17 @@ afterEach(() => {
 });
 
 test('Properly lints and returns errors with server', () => {
-  const results = runEsprint(path.join(__dirname, '../folder'));
-  const expectedError = expect.stringContaining('error  Unexpected var, use let or const instead  no-var');
+  const results = runEsprint(path.join(__dirname, '../folder/'));
+  const expectedError = expect.stringContaining('2 problems (2 errors, 0 warnings)');
   expect(results.error).toBeDefined();
   expect(results.error.stdout.toString()).toEqual(expectedError);
   expect(getPid()).toBeDefined();
 });
 
 test('Properly lints and returns errors without server', () => {
-  const results = runEsprint(path.join(__dirname, '../folder'), 'check');
-  const expectedError = expect.stringContaining('error  Unexpected var, use let or const instead  no-var');
+  const results = runEsprint(path.join(__dirname, '../folder/'), 'check');
+  const expectedError = expect.stringContaining('2 problems (2 errors, 0 warnings)');
+  expect(results.error).toBeDefined();
   expect(results.error.stdout.toString()).toEqual(expectedError);
   expect(getPid()).toBeUndefined();
 });


### PR DESCRIPTION
Fixes #58 
We weren't setting up the server with the correct `cwd`. In this PR we force glob to use the project root as the `cwd` and always return full absolute paths