### PR TITLE
Update JSON-outputting logic directly from the ESLint instance

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,5 +5,6 @@
         "node": 4
       }
     }]
-  ]
+  ],
+  "plugins": ["transform-class-properties"]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -5,6 +5,5 @@
         "node": 4
       }
     }]
-  ],
-  "plugins": ["transform-class-properties"]
+  ]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+    "parser": "babel-eslint",
     "env": {
         "es6": true,
         "node": true

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.24.0",
+    "babel-eslint": "^7.2.3",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-preset-env": "^1.2.2",
     "eslint": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   "devDependencies": {
     "babel-cli": "^6.24.0",
     "babel-eslint": "^7.2.3",
-    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-preset-env": "^1.2.2",
     "eslint": "^4.0.0",
     "jest": "^20.0.4"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.24.0",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-preset-env": "^1.2.2",
     "eslint": "^4.0.0",
     "jest": "^20.0.4"

--- a/src/Client.js
+++ b/src/Client.js
@@ -2,26 +2,22 @@ import dnode from 'dnode';
 import { CLIEngine } from 'eslint';
 import { clearLine } from './cliUtils';
 
-const eslint = new CLIEngine();
-
-function prettyPrintResults(results) {
-  const formatter = eslint.getFormatter();
-  console.log(formatter(results));
-}
-
 export default class Client {
-  constructor(port) {
+  constructor(options) {
+    const { port, json } = options;
+    const eslint = new CLIEngine();
     this.port = port;
+    this.formatter = json ? eslint.getFormatter('json') : eslint.getFormatter();
   }
 
-  connect() {
+  connect = () => {
     const d = dnode.connect(this.port);
     d.on('remote', function(remote) {
       setInterval(() => {
         remote.status('', results => {
           if (!results.message) {
             d.end();
-            prettyPrintResults(results.records);
+            console.log(this.formatter(results.records));
             process.exit(results && results.errorCount > 0 ? 1 : 0);
           } else {
             clearLine();

--- a/src/Client.js
+++ b/src/Client.js
@@ -12,12 +12,13 @@ export default class Client {
 
   connect = () => {
     const d = dnode.connect(this.port);
+    const formatter = this.formatter;
     d.on('remote', function(remote) {
       setInterval(() => {
         remote.status('', results => {
           if (!results.message) {
             d.end();
-            console.log(this.formatter(results.records));
+            console.log(formatter(results.records));
             process.exit(results && results.errorCount > 0 ? 1 : 0);
           } else {
             clearLine();

--- a/src/Client.js
+++ b/src/Client.js
@@ -10,7 +10,7 @@ export default class Client {
     this.formatter = json ? eslint.getFormatter('json') : eslint.getFormatter();
   }
 
-  connect = () => {
+  connect() {
     const d = dnode.connect(this.port);
     const formatter = this.formatter;
     d.on('remote', function(remote) {

--- a/src/commands/check.js
+++ b/src/commands/check.js
@@ -28,12 +28,8 @@ export const check = (options) => {
         return record.warningCount > 0 || record.errorCount > 0;
       });
 
-      if (json) {
-        console.log(JSON.stringify(records));
-      } else {
-        const formatter = eslint.getFormatter();
-        console.log(formatter(records));
-      }
+      const formatter = json ? eslint.getFormatter("json") : eslint.getFormatter();
+      console.log(formatter(records));
       process.exit(results && results.errorCount > 0 ? 1 : 0);
     });
 };

--- a/src/commands/check.js
+++ b/src/commands/check.js
@@ -28,7 +28,7 @@ export const check = (options) => {
         return record.warningCount > 0 || record.errorCount > 0;
       });
 
-      const formatter = json ? eslint.getFormatter("json") : eslint.getFormatter();
+      const formatter = json ? eslint.getFormatter('json') : eslint.getFormatter();
       console.log(formatter(records));
       process.exit(results && results.errorCount > 0 ? 1 : 0);
     });

--- a/src/commands/connect.js
+++ b/src/commands/connect.js
@@ -4,7 +4,7 @@ import { isPortTaken } from '../util';
 import { clearLine } from '../cliUtils';
 import Client from '../Client';
 
-export const connect = (options, eslint) => {
+export const connect = (options) => {
   const args = [];
   for (const key in options) {
     args.push(`--${key}=${options[key]}`);
@@ -14,7 +14,7 @@ export const connect = (options, eslint) => {
 
   isPortTaken(port).then(isTaken => {
     // start the server if it isn't running
-    const client = new Client(port, eslint);
+    const client = new Client(options);
 
     if (!isTaken) {
       const child = fork(

--- a/yarn.lock
+++ b/yarn.lock
@@ -232,6 +232,15 @@ babel-core@^6.0.0, babel-core@^6.24.1:
     slash "^1.0.0"
     source-map "^0.5.0"
 
+babel-eslint@^7.2.3:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-7.2.3.tgz#b2fe2d80126470f5c19442dc757253a897710827"
+  dependencies:
+    babel-code-frame "^6.22.0"
+    babel-traverse "^6.23.1"
+    babel-types "^6.23.0"
+    babylon "^6.17.0"
+
 babel-generator@^6.18.0, babel-generator@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.24.1.tgz#e715f486c58ded25649d888944d52aa07c5d9497"
@@ -678,7 +687,7 @@ babel-template@^6.16.0, babel-template@^6.24.1:
     babylon "^6.11.0"
     lodash "^4.2.0"
 
-babel-traverse@^6.18.0, babel-traverse@^6.24.1:
+babel-traverse@^6.18.0, babel-traverse@^6.23.1, babel-traverse@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.24.1.tgz#ab36673fd356f9a0948659e7b338d5feadb31695"
   dependencies:
@@ -692,7 +701,7 @@ babel-traverse@^6.18.0, babel-traverse@^6.24.1:
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1:
+babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.24.1.tgz#a136879dc15b3606bda0d90c1fc74304c2ff0975"
   dependencies:
@@ -701,7 +710,7 @@ babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1:
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babylon@^6.11.0, babylon@^6.13.0, babylon@^6.15.0:
+babylon@^6.11.0, babylon@^6.13.0, babylon@^6.15.0, babylon@^6.17.0:
   version "6.17.1"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.1.tgz#17f14fddf361b695981fe679385e4f1c01ebd86f"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -382,6 +382,10 @@ babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
 
+babel-plugin-syntax-class-properties@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
+
 babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
@@ -397,6 +401,15 @@ babel-plugin-transform-async-to-generator@^6.22.0:
     babel-helper-remap-async-to-generator "^6.24.1"
     babel-plugin-syntax-async-functions "^6.8.0"
     babel-runtime "^6.22.0"
+
+babel-plugin-transform-class-properties@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz#6a79763ea61d33d36f37b611aa9def81a81b46ac"
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-plugin-syntax-class-properties "^6.8.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
 
 babel-plugin-transform-es2015-arrow-functions@^6.22.0:
   version "6.22.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -391,10 +391,6 @@ babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
 
-babel-plugin-syntax-class-properties@^6.8.0:
-  version "6.13.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
-
 babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
@@ -410,15 +406,6 @@ babel-plugin-transform-async-to-generator@^6.22.0:
     babel-helper-remap-async-to-generator "^6.24.1"
     babel-plugin-syntax-async-functions "^6.8.0"
     babel-runtime "^6.22.0"
-
-babel-plugin-transform-class-properties@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz#6a79763ea61d33d36f37b611aa9def81a81b46ac"
-  dependencies:
-    babel-helper-function-name "^6.24.1"
-    babel-plugin-syntax-class-properties "^6.8.0"
-    babel-runtime "^6.22.0"
-    babel-template "^6.24.1"
 
 babel-plugin-transform-es2015-arrow-functions@^6.22.0:
   version "6.22.0"


### PR DESCRIPTION
Since the ESLint CLIEngine already has `json` as a [formatter option](http://eslint.org/docs/user-guide/formatters/#json), we can simplify the way we output JSON to the console. This PR updates that logic for `check` and the `connect` commands.