### PR TITLE
Open up esprint to allow for any of ESLint's built-in formatters

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -4,10 +4,10 @@ import { clearLine } from './cliUtils';
 
 export default class Client {
   constructor(options) {
-    const { port, json } = options;
+    const { port, formatter } = options;
     const eslint = new CLIEngine();
     this.port = port;
-    this.formatter = json ? eslint.getFormatter('json') : eslint.getFormatter();
+    this.formatter = eslint.getFormatter(formatter);
   }
 
   connect() {

--- a/src/cli.js
+++ b/src/cli.js
@@ -37,6 +37,11 @@ const getEsprintOptions = (argv) => {
       options.workers = argv.workers;
     }
 
+    // ESLint-specific options
+    if (argv.formatter || argv.f) {
+      Object.assign(options, {formatter: argv.formatter});
+    }
+
     return options;
   }
 };
@@ -58,9 +63,6 @@ yargs
     if (!options.port) {
       process.exit(1);
     } else {
-      if (argv.json) {
-        Object.assign(options, {json: argv.json});
-      }
       connect(options);
     }
   })

--- a/src/cli.js
+++ b/src/cli.js
@@ -39,7 +39,7 @@ const getEsprintOptions = (argv) => {
 
     // ESLint-specific options
     if (argv.formatter || argv.f) {
-      Object.assign(options, {formatter: argv.formatter});
+      Object.assign(options, {formatter: argv.f ? argv.f : argv.formatter});
     }
 
     return options;

--- a/src/cli.js
+++ b/src/cli.js
@@ -38,8 +38,8 @@ const getEsprintOptions = (argv) => {
     }
 
     // ESLint-specific options
-    if (argv.formatter || argv.f) {
-      Object.assign(options, {formatter: argv.f ? argv.f : argv.formatter});
+    if (argv.format || argv.f) {
+      Object.assign(options, {formatter: argv.f ? argv.f : argv.format});
     }
 
     return options;

--- a/src/commands/check.js
+++ b/src/commands/check.js
@@ -8,7 +8,7 @@ export const check = (options) => {
   const {
     workers,
     paths,
-    json,
+    formatter,
     rcPath,
   } = options;
 
@@ -28,8 +28,8 @@ export const check = (options) => {
         return record.warningCount > 0 || record.errorCount > 0;
       });
 
-      const formatter = json ? eslint.getFormatter('json') : eslint.getFormatter();
-      console.log(formatter(records));
+      const lintFormatter = eslint.getFormatter(formatter);
+      console.log(lintFormatter(records));
       process.exit(results && results.errorCount > 0 ? 1 : 0);
     });
 };


### PR DESCRIPTION
As title. First PR in a series to allow esprint to be more compatible with ESLint's CLI. 