### PR TITLE
Add a script to create a test sub-folder with relevant fixtures

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "prepublish": "yarn run build",
     "start": "babel --watch src --out-dir build",
     "deps": "node ./scripts/installDependencies.js",
+    "create-test": "node ./scripts/create-test.js",
     "lint": "eslint src tests"
   },
   "repository": {
@@ -43,6 +44,7 @@
     "babel-cli": "^6.24.0",
     "babel-eslint": "^7.2.3",
     "babel-preset-env": "^1.2.2",
+    "chalk": "^2.0.1",
     "eslint": "^4.0.0",
     "jest": "^20.0.4"
   }

--- a/scripts/create-test.js
+++ b/scripts/create-test.js
@@ -29,7 +29,6 @@ afterEach(() => {
 const esprintrc = `
 {
   "port": 5004 ,
-  "workers": 1,
   "paths": [
     "fixture.js"
   ],

--- a/scripts/create-test.js
+++ b/scripts/create-test.js
@@ -1,0 +1,89 @@
+// Creates a test directory with all relevant fixtures for writing tests
+// Usage: yarn run create-test [test-name]
+
+const path = require('path');
+const fs = require('fs');
+const chalk = require('chalk');
+const argv = require('yargs').argv;
+
+const testName = argv._[0];
+const testFile = `${testName}.test.js`; 
+const testFolder = `__tests__`;
+
+const imports = ` 
+const path = require('path');
+const runEsprint = require('../../runEsprint.js');
+const killProcess = require('../../killProcess.js');
+`;
+
+const hooks = `
+beforeEach(() => {
+  killProcess();
+});
+
+afterEach(() => {
+  killProcess();
+});
+`;
+
+const esprintrc = `
+{
+  "port": 5004 ,
+  "workers": 1,
+  "paths": [
+    "fixture.js"
+  ],
+
+  "ignored": [
+    "**/node_modules/**/*"
+  ]
+}
+`;
+
+const eslintrc = `{
+  "rules": {
+    "no-var": 2
+  },
+  "env": {
+    "es6": true
+  },
+  "root": true
+}
+`;
+
+const files = {
+  fixture: {
+    name: 'fixture.js',
+    content: 'var x=0;\nconsole.log(x);'
+  }, 
+
+  rc: {
+    name: '.esprintrc',
+    content: esprintrc
+  }, 
+
+  ignore: {
+    name: '.eslintignore', 
+    content: '__tests__/*'
+  }, 
+
+  eslint: {
+    name: '.eslintrc.json', 
+    content: eslintrc
+  }
+}
+
+const folder = path.join('./tests', testName);
+const subFolder = path.join('./tests', testName, testFolder);
+
+fs.mkdirSync(folder);
+fs.mkdirSync(subFolder);
+fs.writeFileSync(path.join(subFolder, testFile), [imports, hooks].join('\n')); 
+
+Object.keys(files).forEach((file) => {
+  const { name, content } = files[file];
+  fs.writeFileSync(path.join(folder, name), content); 
+});
+
+console.log(chalk.green(`Successfully created ${testName} test sub-folder!`));
+console.log(chalk.green(`You can find it under tests/${testName}.`));

--- a/yarn.lock
+++ b/yarn.lock
@@ -79,6 +79,12 @@ ansi-styles@^3.0.0:
   dependencies:
     color-convert "^1.0.0"
 
+ansi-styles@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.1.0.tgz#09c202d5c917ec23188caa5c9cb9179cd9547750"
+  dependencies:
+    color-convert "^1.0.0"
+
 anymatch@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.0.tgz#a3e52fa39168c825ff57b0248126ce5a8ff95507"
@@ -830,6 +836,14 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chalk@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.0.1.tgz#dbec49436d2ae15f536114e76d14656cdbc0f44d"
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
+
 chokidar@^1.6.1:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
@@ -1471,6 +1485,10 @@ has-ansi@^2.0.0:
 has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
+
+has-flag@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
 
 has-unicode@^2.0.0:
   version "2.0.1"
@@ -2945,6 +2963,12 @@ supports-color@^3.1.2:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:
     has-flag "^1.0.0"
+
+supports-color@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.2.0.tgz#ad986dc7eb2315d009b4d77c8169c2231a684037"
+  dependencies:
+    has-flag "^2.0.0"
 
 symbol-tree@^3.2.1:
   version "3.2.2"


### PR DESCRIPTION
I find it somewhat tedious to manually copy+paste exiting tests with all the fixtures that they come with, so I wrote a simple script that sets up most of the fixture boilerplate instead. Usage is `yarn run create-test [test_name]`. 