### PR TITLE
Remove trailing comma from .esprintrc example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A sample `.esprintrc` file:
 {
   "paths": [
     "foo/*.js",
-    "bar/**/*.js",
+    "bar/**/*.js"
   ],
   "ignored": [
     "**/node_modules/**/*"


### PR DESCRIPTION
I was trying this project out and copy-pasted the example `.esprintrc` file from the readme. On running `esprint check`, I encountered this error:

```bash
⨠ $(npm bin)/esprint check
/<redacted>/node_modules/esprint/node_modules/yargs/yargs.js:1079
      else throw err
           ^

SyntaxError: Unexpected token ] in JSON at position 52
```