### PR TITLE
fix typo in dnode dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lodash": "^4.17.15"
   },
   "dependencies": {
-    "dnode": "https://github.com/christianvuerings/dnode/#e08e620b18c9086d47fe68e08328b19465c62fb7",
+    "dnode": "https://github.com/christianvuerings/dnode#e08e620b18c9086d47fe68e08328b19465c62fb7",
     "fb-watchman": "^2.0.0",
     "glob": "^7.1.4",
     "sane": "^4.1.0",


### PR DESCRIPTION
On master, I was unable to use this dependency in another project, and was getting this error when running `yarn install` in the repo: 
```
➜  esprint git:(master) yarn
yarn install v1.19.2
[1/5] 🔍  Validating package.json...
[2/5] 🔍  Resolving packages...
[3/5] 🚚  Fetching packages...
error Command failed.
Exit code: 128
Command: git
Arguments: ls-remote --tags --heads https://github.com/christianvuerings/dnode/
Directory: /opt/projects/esprint
Output:
ERROR: Repository not found.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

This fixes it by fixing the typo in the dependency. 

## Test plan
`yarn install` works