### PR TITLE
Add Node.js 14 to list of testing instances

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: [12]
+        node_version: [12, 14]
     steps:
       - name: Checkout the Git repository
         uses: actions/checkout@v1


### PR DESCRIPTION
Node.js 14 became the active LTS version on 2020-10-27:
https://nodejs.org/en/about/releases/ 