### PR TITLE
Use jest-worker instead of node-worker-farm

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,2 +1,3 @@
 [*]
 indent_size = 2
+indent_style = space

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: [12, 14]
+        node_version: [12, 14, 15]
     steps:
       - name: Checkout the Git repository
         uses: actions/checkout@v1

--- a/package.json
+++ b/package.json
@@ -30,18 +30,18 @@
     "sshpk": "^1.16.1"
   },
   "dependencies": {
-		"fb-watchman": "^2.0.0",
+    "fb-watchman": "^2.0.0",
     "glob": "^7.1.4",
-		"jayson": "^3.3.4",
+    "jayson": "^3.3.4",
+    "jest-worker": "^26.6.2",
     "sane": "^4.1.0",
-    "worker-farm": "^1.7.0",
     "yargs": "^14.0.0"
   },
   "peerDependencies": {
     "eslint": ">=3"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=12"
   },
   "bin": {
     "esprint": "build/cli.js"

--- a/src/LintWorker.js
+++ b/src/LintWorker.js
@@ -10,11 +10,13 @@ const lintFile = (fileArg, fix) => {
   return report.results;
 };
 
-module.exports = (options, callback) => {
-  const results = lintFile(options.fileArg, options.fix);
-  if (options.suppressWarnings) {
-    callback(null, CLIEngine.getErrorResults(results));
-  } else {
-    callback(null, results);
-  }
-};
+export async function worker({
+  fileArg,
+  fix,
+  suppressWarnings
+}) {
+  return new Promise((resolve) => {
+    const results = lintFile(fileArg, fix);
+    resolve(suppressWarnings ? CLIEngine.getErrorResults(results) : results);
+  });
+}

--- a/src/commands/check.js
+++ b/src/commands/check.js
@@ -2,7 +2,6 @@ import glob from 'glob';
 import path from 'path';
 import { CLIEngine } from 'eslint';
 import LintRunner from '../LintRunner';
-import { flatten } from '../util';
 
 export const check = (options) => {
   const {
@@ -19,7 +18,7 @@ export const check = (options) => {
   const rcDir = path.dirname(rcPath);
   const eslint = new CLIEngine({ cwd: rcDir });
 
-  const filePaths = flatten(paths.map(globPath => glob.sync(globPath, { cwd: rcDir, absolute: true })));
+  const filePaths = (paths.map(globPath => glob.sync(globPath, { cwd: rcDir, absolute: true })) || []).flat();
   // filter out the files that we tell eslint to ignore
   const nonIgnoredFilePaths = filePaths.filter((filePath) => {
     return !(eslint.isPathIgnored(filePath) || filePath.indexOf('eslint') !== -1);

--- a/src/util.js
+++ b/src/util.js
@@ -2,32 +2,6 @@ import net from 'net';
 import fs from 'fs';
 import path from 'path';
 
-export const promisify = (fn) => {
-  return function() {
-    var args = Array.prototype.slice.call(arguments);
-    return new Promise(function(resolve, reject) {
-      args.push(function(err, res) {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(res);
-        }
-      });
-
-      fn.apply(this, args);
-    });
-  };
-};
-
-export const flatten = (array) => {
-  return array.reduce(
-    function(acc, curr) {
-      return curr.concat(acc);
-    },
-    []
-  );
-};
-
 export const isPortTaken = (port) => {
   return new Promise((resolve, reject) => {
     const tester = net

--- a/yarn.lock
+++ b/yarn.lock
@@ -1868,13 +1868,6 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-errno@~0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618"
-  integrity sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==
-  dependencies:
-    prr "~1.0.1"
-
 error-ex@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
@@ -3349,6 +3342,15 @@ jest-worker@^24.6.0, jest-worker@^24.9.0:
     merge-stream "^2.0.0"
     supports-color "^6.1.0"
 
+jest-worker@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-26.6.2.tgz#7f72cbc4d643c365e27b9fd775f9d0eaa9c7a8ed"
+  integrity sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==
+  dependencies:
+    "@types/node" "*"
+    merge-stream "^2.0.0"
+    supports-color "^7.0.0"
+
 jest@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest/-/jest-24.9.0.tgz#987d290c05a08b52c56188c1002e368edb007171"
@@ -4236,11 +4238,6 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.3"
 
-prr@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
-  integrity sha1-0/wRS6BplaRexok/SEzrHXj19HY=
-
 psl@^1.1.24, psl@^1.1.28:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.4.0.tgz#5dd26156cdb69fa1fdb8ab1991667d3f80ced7c2"
@@ -4941,6 +4938,13 @@ supports-color@^6.1.0:
   dependencies:
     has-flag "^3.0.0"
 
+supports-color@^7.0.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
+
 supports-color@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
@@ -5316,13 +5320,6 @@ wordwrap@~0.0.2:
 wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
-
-worker-farm@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.7.0.tgz#26a94c5391bbca926152002f69b84a4bf772e5a8"
-  integrity sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==
-  dependencies:
-    errno "~0.1.7"
 
 wrap-ansi@^5.1.0:
   version "5.1.0"


### PR DESCRIPTION
[jest-worker](https://github.com/facebook/jest/tree/master/packages/) is:
* Actively maintained. `node-worker-farm`'s last commit was over 2 years ago.
* Can leverage [worker threads](https://nodejs.org/docs/latest-v12.x/api/worker_threads.html)

### Note
We now require Node.js > 12:
* Leverage worker threads (stable since v12).
* `.flat` requires Node.js > 11.