### PR TITLE
Use chokidar instead of sane/fb-watchman

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,10 @@
   },
   "homepage": "https://github.com/pinterest/esprint#readme",
   "dependencies": {
-    "fb-watchman": "^2.0.1",
+    "chokidar": "^3.4.3",
     "glob": "^7.1.6",
     "jayson": "^3.3.4",
     "jest-worker": "^26.6.2",
-    "sane": "^4.1.0",
     "yargs": "^16.2.0"
   },
   "peerDependencies": {

--- a/src/Server.js
+++ b/src/Server.js
@@ -1,7 +1,7 @@
+import chokidar from 'chokidar';
 import glob from 'glob';
 import jayson from 'jayson';
 import path from 'path';
-import sane from 'sane';
 import LintRunner from './LintRunner';
 import { CLIEngine } from 'eslint';
 
@@ -50,11 +50,11 @@ export default class Server {
   }
 
   _setupWatcher(root, paths, ignored) {
-    const watcher = sane(root, {
-      glob: paths,
+    const watcher = chokidar.watch(paths, {
+      disableGlobbing: true,
       ignored: ignored,
-      dot: true,
-      watchman: process.env.NODE_ENV !== 'test',
+      ignoreInitial: true,
+      ignorePermissionErrors: true,
     });
 
     watcher.on('ready', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1642,7 +1642,7 @@ char-regex@^1.0.2:
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
 
-chokidar@^3.4.0:
+chokidar@^3.4.0, chokidar@^3.4.3:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.3.tgz#c1df38231448e45ca4ac588e6c79573ba6a57d5b"
   integrity sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==
@@ -2270,7 +2270,7 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
-fb-watchman@^2.0.0, fb-watchman@^2.0.1:
+fb-watchman@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.1.tgz#fc84fb39d2709cf3ff6d743706157bb5708a8a85"
   integrity sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==
@@ -4175,7 +4175,7 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sane@^4.0.3, sane@^4.1.0:
+sane@^4.0.3:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/sane/-/sane-4.1.0.tgz#ed881fd922733a6c461bc189dc2b6c006f3ffded"
   integrity sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==


### PR DESCRIPTION
[sane](https://github.com/amasad/sane):
* Has multiple outdated dependencies with security vulnerabilities: https://github.com/amasad/sane/issues/159
* Relies on `watchman` - a native dependency
* Requires us to have a conditional for testing purposes

So let's use [chokidar](https://github.com/paulmillr/chokidar) instead which is also used by VS Code.

Fixes #117 