### PR TITLE
Improve error message when no server is running

### DIFF
--- a/src/commands/stop.js
+++ b/src/commands/stop.js
@@ -9,8 +9,15 @@ export const stop = () => {
 
   if (rc.port) {
     const { port } = rc;
-    const command = `lsof -i TCP:${port} | grep LISTEN | awk '{print $2}' | xargs kill -9`;
-    execSync(command);
+    const command = `kill -9 $(lsof -t -i tcp:${port})`;
+    try {
+      execSync(command, {
+        stdio: 'ignore'
+      });
+    } catch (error) {
+      console.log(`No server runs on port ${port}`);
+      return;
+    }
     console.log(`Server running on port ${port} found and stopped`);
   } else {
     console.warn('No port specified in `.esprintrc` file');


### PR DESCRIPTION
We currently throw an error when no background server runs and try to stop it. Instead, let's show a warning message

### Before
![Screen Shot 2020-12-16 at 9 00 36 AM](https://user-images.githubusercontent.com/127199/102321181-282ec300-3f32-11eb-8807-870e900094bb.png)

### After
![Screen Shot 2020-12-16 at 8 59 08 AM](https://user-images.githubusercontent.com/127199/102321197-2c5ae080-3f32-11eb-8dd5-8952560e2689.png)
