### PR TITLE
Allow linting files with "eslint" in name

### DIFF
--- a/src/Server.js
+++ b/src/Server.js
@@ -120,7 +120,7 @@ export default class Server {
   }
 
   lintFile(file) {
-    if (eslint.isPathIgnored(file) || file.indexOf('eslint') !== -1) {
+    if (eslint.isPathIgnored(file)) {
       return;
     }
     this.filesToProcess++;

--- a/src/commands/check.js
+++ b/src/commands/check.js
@@ -22,7 +22,7 @@ export const check = (options) => {
   const filePaths = (paths.map(globPath => glob.sync(globPath, { cwd: rcDir, absolute: true, ignore: ignored })) || []).flat();
   // filter out the files that we tell eslint to ignore
   const nonIgnoredFilePaths = filePaths.filter((filePath) => {
-    return !(eslint.isPathIgnored(filePath) || filePath.indexOf('eslint') !== -1);
+    return !eslint.isPathIgnored(filePath);
   });
 
   lintRunner.run(nonIgnoredFilePaths)


### PR DESCRIPTION
It is impossible to lint .eslintrc.js because of this hardcoded ignore of files with "eslint" in the name.

There are various ways of ignoring files if it's desired to ignore these files. But I want to also lint my .eslintrc.js file.