### PR TITLE
Re-introduce watchman + CLI flags: noWatchman / esprintDebug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: [12, 14, 15]
+        node_version: [12, 14, 16]
     steps:
       - name: Checkout the Git repository
         uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -18,14 +18,16 @@ A sample `.esprintrc` file:
 
 Options:
 
-|       Name        |       Type        | Description                                                                                                       |
-| :---------------: | :---------------: | :---------------------------------------------------------------------------------------------------------------- |
-|    **`paths`**    | `{Array<String>}` | Glob-style paths for files to include when linting                                                                |
-|   **`ignored`**   | `{Array<String>}` | Glob-style paths to ignore (not watch) during dev mode for better performance (`.eslintignore` applies as normal) |
-|    **`port`**     |    `{Number}`     | (optional) Run the esprint background server on a specific port                                                   |
-|  **`formatter`**  |    `{string}`     | (optional) Use a specific output format - default: stylish                                                        |
-|    **`quiet`**    |    `{boolean}`    | (optional) Report errors only - default: false                                                                    |
-| **`maxWarnings`** |    `{number}`     | (optional) The max number of warnings that should trigger a failure. The default is to not fail on warnings       |
+|        Name        |       Type        | Description                                                                                                       |
+| :----------------: | :---------------: | :---------------------------------------------------------------------------------------------------------------- |
+|    **`paths`**     | `{Array<String>}` | Glob-style paths for files to include when linting                                                                |
+|   **`ignored`**    | `{Array<String>}` | Glob-style paths to ignore (not watch) during dev mode for better performance (`.eslintignore` applies as normal) |
+|     **`port`**     |    `{Number}`     | (optional) Run the esprint background server on a specific port                                                   |
+|  **`formatter`**   |    `{string}`     | (optional) Use a specific output format - default: stylish                                                        |
+|    **`quiet`**     |    `{boolean}`    | (optional) Report errors only - default: false                                                                    |
+| **`maxWarnings`**  |    `{number}`     | (optional) The max number of warnings that should trigger a failure. The default is to not fail on warnings       |
+| **`esprintDebug`** |    `{boolean}`    | (optional) Print debug output for esrpint. Should only be used when you're running into issues                    |
+|  **`noWatchman`**  |    `{boolean}`    | (optional) Disable watchman                                                                                       |
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/pinterest/esprint#readme",
   "dependencies": {
+    "fb-watchman": "^2.0.1",
     "glob": "^7.1.7",
     "jayson": "^3.6.3",
     "jest-worker": "^27.0.2",
@@ -42,8 +43,8 @@
   "devDependencies": {
     "@babel/cli": "^7.14.3",
     "@babel/core": "^7.14.3",
-    "@babel/preset-env": "^7.14.4",
     "@babel/eslint-parser": "^7.14.4",
+    "@babel/preset-env": "^7.14.4",
     "babel-jest": "^27.0.2",
     "chalk": "^4.1.1",
     "eslint": "7.15.0",

--- a/src/Server.js
+++ b/src/Server.js
@@ -11,7 +11,8 @@ const eslint = new ESLint({ cwd: ROOT_DIR });
 
 export default class Server {
   constructor(options) {
-    const { workers, port, paths, ignored, rcPath, quiet, fix } = options;
+    const { workers, port, paths, ignored, rcPath, quiet, fix, noWatchman } =
+      options;
 
     this.port = port;
     this.rcPath = rcPath;
@@ -20,6 +21,7 @@ export default class Server {
     this.filesToProcess = 0;
     this.initializing = true;
     this.lintRunner = new LintRunner(workers, !!quiet, fix === "true");
+    this.noWatchman = noWatchman;
 
     const rootDir = path.dirname(this.rcPath);
 
@@ -54,7 +56,7 @@ export default class Server {
       glob: paths,
       ignored: ignored,
       dot: true,
-      watchman: false,
+      watchman: this.noWatchman ? false : true,
     });
 
     watcher.on("ready", async () => {

--- a/src/cli.js
+++ b/src/cli.js
@@ -46,6 +46,12 @@ const getEsprintOptions = (argv) => {
     if (argv.fix) {
       Object.assign(options, { fix: true });
     }
+    if (argv.esprintDebug) {
+      Object.assign(options, { esprintDebug: true });
+    }
+    if (argv.noWatchman) {
+      Object.assign(options, { noWatchman: argv.noWatchman });
+    }
 
     // NB: Passing --quiet as a number for compatibility with yargs
     options.quiet = options.quiet || argv.quiet ? 1 : 0;
@@ -59,6 +65,9 @@ const usage = `Spins up a server on a specified port to run eslint in parallel.
 
 yargs
   .usage(usage)
+  .parserConfiguration({
+    "boolean-negation": false,
+  })
   .command(
     "stop",
     "Stops running the background server",

--- a/src/commands/connect.js
+++ b/src/commands/connect.js
@@ -20,7 +20,7 @@ export const connect = async (options) => {
 
   if (!isTaken) {
     const child = fork(require.resolve("../startServer.js"), args, {
-      silent: true,
+      silent: options.esprintDebug ? false : true,
     });
 
     child.on("message", async (message) => {

--- a/tests/runEsprint.js
+++ b/tests/runEsprint.js
@@ -5,7 +5,7 @@ const esprintPath = path.join(__dirname, '../build/cli.js');
 
 function runEsprint(cwd, args) {
   try {
-    const stdout = execSync(`node ${esprintPath} ${args || ''}`, {
+    const stdout = execSync(`node ${esprintPath} ${args || ''} --no-watchman`, {
       cwd: cwd
     });
     return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2291,7 +2291,7 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
-fb-watchman@^2.0.0:
+fb-watchman@^2.0.0, fb-watchman@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.1.tgz#fc84fb39d2709cf3ff6d743706157bb5708a8a85"
   integrity sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==


### PR DESCRIPTION
We saw the following exception when trying to run `esprint` locally without watchman:

```
Initializingevents.js:292
      throw er; // Unhandled 'error' event
      ^

Error: EMFILE: too many open files, watch
    at FSEvent.FSWatcher._handle.onchange (internal/fs/watchers.js:178:28)
Emitted 'error' event on NodeWatcher instance at:
    at NodeWatcher.checkedEmitError (/Users/cvuerings/code/esprint/node_modules/sane/src/node_watcher.js:143:12)
    at FSWatcher.emit (events.js:315:20)
    at FSEvent.FSWatcher._handle.onchange (internal/fs/watchers.js:184:12) {
  errno: -24,
  syscall: 'watch',
  code: 'EMFILE',
  filename: null
}
/Users/cvuerings/code/esprint/build/Client.js:37
          throw error;
          ^

Error: read ECONNRESET
    at TCP.onStreamRead (internal/stream_base_commons.js:209:20) {
  errno: -54,
  code: 'ECONNRESET',
  syscall: 'read'
}
```

So re-introducing `watchman` & add `esprintDebug` and `noWatchman` options to our list of CLI flags