### PR TITLE
Fix: avoid crash on directories with dots in them (check command)

### DIFF
--- a/src/commands/check.js
+++ b/src/commands/check.js
@@ -21,7 +21,7 @@ export const check = async (options) => {
 
   const filePaths = (
     paths.map((globPath) =>
-      glob.sync(globPath, { cwd: rcDir, absolute: true, ignore: ignored })
+      glob.sync(globPath, { cwd: rcDir, absolute: true, ignore: ignored, nodir: true })
     ) || []
   ).flat();
   // filter out the files that we tell eslint to ignore


### PR DESCRIPTION
Similar to #163 but now for the `check` command which we use in CI environments